### PR TITLE
feat: gauge de medo e ganância (VIX) com endpoint e gráfico semicircular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ coverage/
 .env
 
 .venv/
+
+.vscode/

--- a/backend/server.js
+++ b/backend/server.js
@@ -127,6 +127,30 @@ app.post('/api/treinar', async (req, res) => {
   }
 });
 
+// ==============================
+// 😨 Rota: Indicador do Medo (VIX)
+// ==============================
+app.get('/api/indicador-medo', async (req, res) => {
+  try {
+    // Endpoint público do Yahoo Finance para o VIX
+    const url = 'https://query1.finance.yahoo.com/v8/finance/chart/^VIX';
+    const { data } = await axios.get(url);
+    const result = data.chart?.result?.[0];
+    const close = result?.indicators?.quote?.[0]?.close;
+    const timestamps = result?.timestamp;
+    if (!close || !timestamps) {
+      return res.status(500).json({ error: 'Dados do VIX indisponíveis.' });
+    }
+    // Pega o último valor disponível
+    const valorAtual = close[close.length - 1];
+    const dataAtual = new Date(timestamps[timestamps.length - 1] * 1000);
+    return res.json({ valorAtual, dataAtual });
+  } catch (error) {
+    console.error('Erro ao buscar indicador do medo (VIX):', error.message);
+    return res.status(500).json({ error: 'Erro ao buscar indicador do medo.' });
+  }
+});
+
 // ==========================
 // 🚀 Inicialização do servidor
 // ==========================

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -3,6 +3,20 @@
     style="display:block;margin:0 auto 1rem;" />
   <h2>📈 Leitor de Ativos Financeiros</h2>
 
+  <!-- Gauge do Medo/Ganância -->
+  <div style="max-width:400px;margin:2rem auto 1rem;">
+    <h3 style="text-align:center;">😨 Medo & Ganância dos Investidores</h3>
+    <canvas *ngIf="gaugeData" baseChart [data]="gaugeData" [type]="'doughnut'" [options]="gaugeOptions"></canvas>
+    <div *ngIf="medoValor !== null" style="text-align:center;margin-top:0.5rem;">
+      <strong>Índice VIX:</strong> {{ medoValor | number:'1.1-2' }}<br>
+      <span *ngIf="medoValor < 15" style="color:#4caf50;">Ganância (baixo medo)</span>
+      <span *ngIf="medoValor >= 15 && medoValor < 25" style="color:#ff9800;">Neutro</span>
+      <span *ngIf="medoValor >= 25" style="color:#f44336;">Medo (alta volatilidade)</span>
+      <div style="font-size:0.9em;color:#888;">Atualizado em: {{ medoData | date:'short' }}</div>
+    </div>
+    <div *ngIf="gaugeData === null" style="text-align:center;color:#f44336;">Não foi possível obter o índice do medo.</div>
+  </div>
+
   <div class="form-group">
     <div class="form-group">
       <input type="text" [(ngModel)]="codigoAtivo" placeholder="Ex: PETR4, AAPL3, BBDC3" class="input" />
@@ -16,7 +30,7 @@
       </select>
 
       <button (click)="buscarAtivo()" [disabled]="carregando" class="button">
-        {{ carregando ? 'Buscando...' : 'Buscar' }}
+        {{ carregando ? 'Procurando...' : 'Procurar' }}
       </button>
       <!-- <button (click)="treinarModelo()" [disabled]="carregando" class="button">
         {{ carregando ? 'Treinando...' : 'Treinar Modelo com esse Ativo' }}


### PR DESCRIPTION
Adiciona um novo endpoint no backend para obter o índice do medo (VIX) e um gráfico de gauge semicircular no frontend para medir o medo e a ganância dos investidores. O gauge é exibido na tela inicial e classifica o VIX em ganância, neutro ou medo, com cores e legenda.

- Novo endpoint: /api/indicador-medo
- Gráfico de gauge usando ng2-charts/chart.js
- Lógica de cores e faixas para medo/ganância
- Atualização automática ao carregar a página

Closes #<NÚMERO_DO_ISSUE_SE_EXISTIR>